### PR TITLE
Add mouse sensitivity slider to pause menu

### DIFF
--- a/Code/GameManager.gd
+++ b/Code/GameManager.gd
@@ -27,7 +27,7 @@ func _on_resume_pressed() -> void:
 		crosshair.hide()
 		get_tree().paused = true
 		pause_menu.show()
-	else :
+	else:
 		Input.set_mouse_mode(Input.MOUSE_MODE_HIDDEN)
 		crosshair.show()
 		get_tree().paused = false

--- a/Scenes/Game.tscn
+++ b/Scenes/Game.tscn
@@ -29,5 +29,6 @@ texture = ExtResource("4_1l1um")
 script = ExtResource("5_p6bhj")
 
 [connection signal="pressed" from="CanvasLayer/PauseMenu/Panel/VBoxContainer/Resume" to="Manager" method="_on_resume_pressed"]
+[connection signal="value_changed" from="CanvasLayer/PauseMenu/Panel/VBoxContainer/SensitivitySlider" to="CanvasLayer/Crosshair" method="set_sensitivity"]
 
 [editable path="CanvasLayer/PauseMenu"]

--- a/Scenes/PauseMenu.tscn
+++ b/Scenes/PauseMenu.tscn
@@ -40,6 +40,17 @@ grow_vertical = 2
 layout_mode = 2
 text = "Resume"
 
+[node name="MouseSensitivityLabel" type="Label" parent="Panel/VBoxContainer"]
+layout_mode = 2
+text = "Mouse Sensitivity"
+
+[node name="SensitivitySlider" type="HSlider" parent="Panel/VBoxContainer"]
+layout_mode = 2
+min_value = 0.1
+max_value = 2.0
+step = 0.1
+value = 1.0
+
 [node name="Label" type="Label" parent="Panel"]
 layout_mode = 1
 anchors_preset = 5

--- a/UI/Crosshair.gd
+++ b/UI/Crosshair.gd
@@ -1,7 +1,20 @@
 extends Sprite2D
 
+var sensitivity := 1.0
+
 func _ready() -> void:
 	Input.set_mouse_mode(Input.MOUSE_MODE_HIDDEN)
+	Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
+	global_position = get_viewport_rect().size / 2
+
+func _input(event: InputEvent) -> void:
+	if event is InputEventMouseMotion:
+		global_position += event.relative * sensitivity
+		var rect := get_viewport_rect()
+		global_position.x = clamp(global_position.x, rect.position.x, rect.position.x + rect.size.x)
+		global_position.y = clamp(global_position.y, rect.position.y, rect.position.y + rect.size.y)
 
 func _process(delta: float) -> void:
 	global_position = get_viewport().get_mouse_position()
+func set_sensitivity(value: float) -> void:
+	sensitivity = value

--- a/project.godot
+++ b/project.godot
@@ -68,14 +68,15 @@ ui_crouch={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194326,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
-
 aim={
 "deadzone": 0.5,
-"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":2,"pressed":false,"double_click":false,"script":null)]
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":2,"canceled":false,"pressed":false,"double_click":false,"script":null)
+]
 }
 shoot={
 "deadzone": 0.5,
-"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":1,"pressed":false,"double_click":false,"script":null)]
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":1,"canceled":false,"pressed":false,"double_click":false,"script":null)
+]
 }
 
 [rendering]


### PR DESCRIPTION
Introduced a mouse sensitivity slider in the pause menu, connected it to the crosshair to allow real-time adjustment. Updated Crosshair.gd to support sensitivity changes and improved mouse movement handling. Minor code cleanup and updated input mappings in project settings.