### PR TITLE
Sync gun aiming and shooting with crosshair position

### DIFF
--- a/Code/Player.gd
+++ b/Code/Player.gd
@@ -5,6 +5,7 @@ const SPEED = 200  # швидкість пікселів за секунду
 var BulletScene := preload("res://Scenes/Bullet.tscn")
 @onready var gun = $Gun
 @onready var muzzle = $Gun/Muzzle
+@onready var crosshair = get_node("../CanvasLayer/Crosshair")
 
 func _physics_process(delta):
 	var direction = Vector2.ZERO
@@ -33,12 +34,12 @@ func _physics_process(delta):
 	move_and_slide()
 
 func _process(_delta):
-	var mouse_pos = get_global_mouse_position()
+	var mouse_pos = crosshair.global_position
 	gun.look_at(mouse_pos)
 
 	if Input.is_action_just_pressed("shoot"):
 		var bullet = BulletScene.instantiate()
 		bullet.global_position = muzzle.global_position
-		bullet.direction = (get_global_mouse_position() - muzzle.global_position).normalized()
+		bullet.direction = (crosshair.global_position - muzzle.global_position).normalized()
 		bullet.rotation = bullet.direction.angle()
 		get_tree().current_scene.add_child(bullet)

--- a/UI/Crosshair.gd
+++ b/UI/Crosshair.gd
@@ -14,7 +14,5 @@ func _input(event: InputEvent) -> void:
 		global_position.x = clamp(global_position.x, rect.position.x, rect.position.x + rect.size.x)
 		global_position.y = clamp(global_position.y, rect.position.y, rect.position.y + rect.size.y)
 
-func _process(delta: float) -> void:
-	global_position = get_viewport().get_mouse_position()
 func set_sensitivity(value: float) -> void:
 	sensitivity = value


### PR DESCRIPTION
Updated Player.gd to use the crosshair's global position for aiming and bullet direction instead of the raw mouse position. Removed redundant crosshair position update in Crosshair.gd, ensuring the crosshair is only moved via input events. This change improves consistency between the crosshair UI and gameplay mechanics.