### PR TITLE
Add TargetDummy scene and script, update shooting logic

### DIFF
--- a/Code/Player.gd
+++ b/Code/Player.gd
@@ -6,7 +6,6 @@ var BulletScene := preload("res://Scenes/Bullet.tscn")
 @onready var gun = $Gun
 @onready var muzzle = $Gun/Muzzle
 @onready var crosshair = get_node("../CanvasLayer/Crosshair")
-var _ctrl_click_prev := false
 
 func _ready():
 	# Remap crouch to Command key on macOS
@@ -45,8 +44,7 @@ func _physics_process(delta):
 func _process(_delta):
 	var mouse_pos = crosshair.global_position
 	gun.look_at(mouse_pos)
-
-	if Input.is_action_pressed("ui_crouch") and Input.is_action_just_pressed("shoot"):
+	if Input.is_action_just_pressed("shoot"):
 		var bullet = BulletScene.instantiate()
 		bullet.global_position = muzzle.global_position
 		bullet.direction = (crosshair.global_position - muzzle.global_position).normalized()

--- a/Code/TargetDummy.gd
+++ b/Code/TargetDummy.gd
@@ -1,0 +1,8 @@
+extends StaticBody2D
+
+@export var hp := 30
+
+func apply_hit(dmg: int) -> void:
+	hp -= dmg
+	if hp <= 0:
+		queue_free()

--- a/Code/TargetDummy.gd.uid
+++ b/Code/TargetDummy.gd.uid
@@ -1,0 +1,1 @@
+uid://czr5g7j7o5yia

--- a/Scenes/TargetDummy.tscn
+++ b/Scenes/TargetDummy.tscn
@@ -1,0 +1,16 @@
+[gd_scene load_steps=4 format=3 uid="uid://csw3ii8yqgdt7"]
+
+[ext_resource type="Script" uid="uid://czr5g7j7o5yia" path="res://Code/TargetDummy.gd" id="1_mqb0p"]
+
+[sub_resource type="NoiseTexture2D" id="NoiseTexture2D_cvo2p"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_0r0c5"]
+
+[node name="TargetDummy" type="StaticBody2D"]
+script = ExtResource("1_mqb0p")
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+texture = SubResource("NoiseTexture2D_cvo2p")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("RectangleShape2D_0r0c5")


### PR DESCRIPTION
Introduces a TargetDummy scene with a script that handles hit points and destruction on zero HP. Also updates Player.gd to simplify shooting logic by removing the crouch requirement.