### PR TITLE
Add ammo system and HUD display for player

### DIFF
--- a/Code/DevHUD.gd
+++ b/Code/DevHUD.gd
@@ -1,6 +1,8 @@
 extends CanvasLayer
+var player: Node
 
 func _ready():
+	player = get_tree().current_scene.get_node_or_null("Player")
 	visible = true
 	if not has_node("Panel/Label"):
 		var panel := Panel.new(); add_child(panel)
@@ -17,4 +19,11 @@ func _process(delta: float) -> void:
 	@warning_ignore("narrowing_conversion")
 	var fps: int = Engine.get_frames_per_second()
 	var ms: int = snapped(delta * 1000.0, 0.1)
-	$Panel/Label.text = "FPS: %s | Frame: %sms" % [str(fps), str(ms)]
+	if not player:
+		player = get_tree().current_scene.get_node_or_null("Player")
+
+	var ammo_text := ""
+	if player:
+		var ammo: int = player.ammo
+		ammo_text = " | Ammo: %s/%s" % [str(ammo), str(player.MAGAZINE_SIZE)]
+	$Panel/Label.text = "FPS: %s | Frame: %sms%s" % [str(fps), str(ms), ammo_text]

--- a/Code/Player.gd
+++ b/Code/Player.gd
@@ -6,6 +6,8 @@ var BulletScene := preload("res://Scenes/Bullet.tscn")
 @onready var gun = $Gun
 @onready var muzzle = $Gun/Muzzle
 @onready var crosshair = get_node("../CanvasLayer/Crosshair")
+const MAGAZINE_SIZE := 10
+var ammo := MAGAZINE_SIZE
 
 func _ready():
 	# Remap crouch to Command key on macOS
@@ -45,8 +47,12 @@ func _process(_delta):
 	var mouse_pos = crosshair.global_position
 	gun.look_at(mouse_pos)
 	if Input.is_action_just_pressed("shoot"):
-		var bullet = BulletScene.instantiate()
-		bullet.global_position = muzzle.global_position
-		bullet.direction = (crosshair.global_position - muzzle.global_position).normalized()
-		bullet.rotation = bullet.direction.angle()
-		get_tree().current_scene.add_child(bullet)
+		if ammo > 0:
+			var bullet = BulletScene.instantiate()
+			bullet.global_position = muzzle.global_position
+			bullet.direction = (crosshair.global_position - muzzle.global_position).normalized()
+			bullet.rotation = bullet.direction.angle()
+			get_tree().current_scene.add_child(bullet)
+			ammo -= 1
+	if Input.is_action_just_pressed("reload") and ammo < MAGAZINE_SIZE:
+		ammo = MAGAZINE_SIZE

--- a/project.godot
+++ b/project.godot
@@ -79,6 +79,11 @@ shoot={
 ]
 }
 
+reload={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":82,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)]
+}
+
 [rendering]
 
 textures/vram_compression/import_etc2_astc=true


### PR DESCRIPTION
Introduces a magazine-based ammo system to the Player, limiting shooting to available ammo and allowing reloading. The DevHUD now displays current ammo count alongside FPS and frame time. Also adds a 'reload' input action to project settings.