### PR TITLE
Add AmmoCounter HUD and refactor DevHUD

### DIFF
--- a/Code/AmmoCounter.gd
+++ b/Code/AmmoCounter.gd
@@ -1,0 +1,69 @@
+extends CanvasLayer
+
+const PANEL_MARGIN := Vector2(10, 10)
+const PANEL_SIZE := Vector2(260, 40)
+const LABEL_PADDING := Vector2(8, 8)
+
+var player: Node = null
+
+@onready var panel: Panel = _ensure_panel()
+@onready var label: Label = _ensure_label()
+
+func _ready() -> void:
+		visible = true
+		_refresh_player_reference()
+		_configure_panel()
+		_configure_label()
+		_update_text()
+
+func _process(_delta: float) -> void:
+		if not player or not player.is_inside_tree():
+				_refresh_player_reference()
+		_update_text()
+
+func _refresh_player_reference() -> void:
+		var active_scene := get_tree().current_scene
+		player = active_scene.get_node_or_null("Player") if active_scene else null
+
+func _ensure_panel() -> Panel:
+		var existing_panel := get_node_or_null("Panel")
+		if existing_panel:
+				return existing_panel as Panel
+		var new_panel := Panel.new()
+		new_panel.name = "Panel"
+		add_child(new_panel)
+		return new_panel
+
+func _ensure_label() -> Label:
+		if panel.has_node("Label"):
+				return panel.get_node("Label") as Label
+		var new_label := Label.new()
+		new_label.name = "Label"
+		panel.add_child(new_label)
+		return new_label
+
+func _configure_panel() -> void:
+		panel.set_anchors_preset(Control.PRESET_TOP_RIGHT, true)
+		panel.offset_right = -PANEL_MARGIN.x
+		panel.offset_left = panel.offset_right - PANEL_SIZE.x
+		panel.offset_top = PANEL_MARGIN.y
+		panel.offset_bottom = panel.offset_top + PANEL_SIZE.y
+		panel.custom_minimum_size = PANEL_SIZE
+		panel.mouse_filter = Control.MOUSE_FILTER_IGNORE
+
+func _configure_label() -> void:
+		label.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+		label.offset_left = LABEL_PADDING.x
+		label.offset_right = -LABEL_PADDING.x
+		label.offset_top = LABEL_PADDING.y
+		label.offset_bottom = -LABEL_PADDING.y
+		label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+		label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+
+func _update_text() -> void:
+		if label == null:
+				return
+		var ammo_text := "Ammo: --/--"
+		if player:
+				ammo_text = "Ammo: %s/%s" % [str(player.ammo), str(player.MAGAZINE_SIZE)]
+		label.text = ammo_text

--- a/Code/AmmoCounter.gd.uid
+++ b/Code/AmmoCounter.gd.uid
@@ -1,0 +1,1 @@
+uid://dthwca4q5g2hu

--- a/Code/DevHUD.gd
+++ b/Code/DevHUD.gd
@@ -1,8 +1,6 @@
 extends CanvasLayer
-var player: Node
 
 func _ready():
-	player = get_tree().current_scene.get_node_or_null("Player")
 	visible = true
 	if not has_node("Panel/Label"):
 		var panel := Panel.new(); add_child(panel)
@@ -19,11 +17,4 @@ func _process(delta: float) -> void:
 	@warning_ignore("narrowing_conversion")
 	var fps: int = Engine.get_frames_per_second()
 	var ms: int = snapped(delta * 1000.0, 0.1)
-	if not player:
-		player = get_tree().current_scene.get_node_or_null("Player")
-
-	var ammo_text := ""
-	if player:
-		var ammo: int = player.ammo
-		ammo_text = " | Ammo: %s/%s" % [str(ammo), str(player.MAGAZINE_SIZE)]
-	$Panel/Label.text = "FPS: %s | Frame: %sms%s" % [str(fps), str(ms), ammo_text]
+	$Panel/Label.text = "FPS: %s | Frame: %sms" % [str(fps), str(ms)]

--- a/Scenes/Game.tscn
+++ b/Scenes/Game.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3 uid="uid://cq0y0fr2wdd4u"]
+[gd_scene load_steps=8 format=3 uid="uid://cq0y0fr2wdd4u"]
 
 [ext_resource type="Script" uid="uid://bowl2nj1djfm2" path="res://Code/DevHUD.gd" id="1_iukft"]
 [ext_resource type="Script" uid="uid://d2ybbmowtmojb" path="res://Code/GameManager.gd" id="1_kldst"]
@@ -6,6 +6,7 @@
 [ext_resource type="PackedScene" uid="uid://dtcstghkf873q" path="res://Scenes/PauseMenu.tscn" id="3_j5yw3"]
 [ext_resource type="Texture2D" uid="uid://cx7aqwabeukvs" path="res://Assets/crosshair.png" id="4_1l1um"]
 [ext_resource type="Script" uid="uid://efcd6675a348" path="res://UI/Crosshair.gd" id="5_p6bhj"]
+[ext_resource type="Script" uid="uid://dthwca4q5g2hu" path="res://Code/AmmoCounter.gd" id="6_j26lt"]
 
 [node name="Game" type="Node2D"]
 
@@ -27,6 +28,9 @@ process_mode = 1
 scale = Vector2(0.1, 0.1)
 texture = ExtResource("4_1l1um")
 script = ExtResource("5_p6bhj")
+
+[node name="AmmoCounter" type="CanvasLayer" parent="."]
+script = ExtResource("6_j26lt")
 
 [connection signal="pressed" from="CanvasLayer/PauseMenu/Panel/VBoxContainer/Resume" to="Manager" method="_on_resume_pressed"]
 [connection signal="value_changed" from="CanvasLayer/PauseMenu/Panel/VBoxContainer/SensitivitySlider" to="CanvasLayer/Crosshair" method="set_sensitivity"]

--- a/project.godot
+++ b/project.godot
@@ -78,10 +78,10 @@ shoot={
 "events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":1,"canceled":false,"pressed":false,"double_click":false,"script":null)
 ]
 }
-
 reload={
 "deadzone": 0.5,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":82,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)]
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":82,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
 }
 
 [rendering]


### PR DESCRIPTION
Introduced a new AmmoCounter.gd script and node to display the player's ammo count in the HUD. Refactored DevHUD.gd to remove ammo display logic, delegating it to the new AmmoCounter. Updated Game.tscn to include the AmmoCounter node and script. Minor formatting fix in project.godot input map.